### PR TITLE
Hide durability bar for all items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ base {
 }
 
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
+// WARN: When changing this you might also have to change the value in
+// duradisplay.mixins.json
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 //minecraft.accessTransformers.file rootProject.file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -128,6 +130,14 @@ tasks.withType(ProcessResources).configureEach {
         expand replaceProperties
     }
 }
+
+// Required for mixins
+repositories {
+    maven {
+        url = 'https://repo.spongepowered.org/repository/maven-public/'
+    }
+}
+
 
 // Example configuration to allow publishing using the maven-publish plugin
 publishing {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,10 @@ pluginManagement {
         mavenLocal()
         gradlePluginPortal()
         maven { url = 'https://maven.neoforged.net/releases' }
+        maven {
+            name = "Mixin"
+            url "https://repo.spongepowered.org/repository/maven-public/"
+        }
     }
 }
 

--- a/src/main/java/com/leclowndu93150/duradisplay/Main.java
+++ b/src/main/java/com/leclowndu93150/duradisplay/Main.java
@@ -48,8 +48,7 @@ public class Main
 
                 String formattedPercentage = String.format("%.0f%%", durabilityPercentage);
 
-                String string = formattedPercentage;
-                int stringWidth = font.width(string);
+                int stringWidth = font.width(formattedPercentage);
                 int x = ((xPosition + 8) * 2 + 1 + stringWidth / 2 - stringWidth);
                 int y = (yPosition * 2) + 18;
 
@@ -59,7 +58,7 @@ public class Main
                 poseStack.scale(0.5F, 0.5F, 0.5F);
                 poseStack.translate(0.0D, 0.0D, 750.0F);
                 MultiBufferSource.BufferSource multibuffersource$buffersource = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-                font.drawInBatch(string, x, y, color, true, poseStack.last().pose(), multibuffersource$buffersource, Font.DisplayMode.NORMAL, 0, 15728880, false);
+                font.drawInBatch(formattedPercentage, x, y, color, true, poseStack.last().pose(), multibuffersource$buffersource, Font.DisplayMode.NORMAL, 0, 15728880, false);
                 multibuffersource$buffersource.endBatch();
                 poseStack.popPose();
 

--- a/src/main/java/com/leclowndu93150/duradisplay/mixins/GuiGraphicsMixin.java
+++ b/src/main/java/com/leclowndu93150/duradisplay/mixins/GuiGraphicsMixin.java
@@ -1,0 +1,20 @@
+package com.leclowndu93150.duradisplay.mixins;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.client.gui.GuiGraphics;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = GuiGraphics.class)
+public abstract class GuiGraphicsMixin {
+    @ModifyExpressionValue(
+            method = "Lnet/minecraft/client/gui/GuiGraphics;renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/item/ItemStack;isBarVisible()Z"
+            )
+    )
+    private boolean disableBarInGui(boolean barVisible) {
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -22,6 +22,10 @@ license="${mod_license}"
 # The modid of the mod
 modId="${mod_id}" #mandatory
 
+# Location of the mixin config file
+[[mixins]]
+config = "${mod_id}.mixins.json"
+
 # The version number of the mod
 version="${mod_version}" #mandatory
 

--- a/src/main/resources/duradisplay.mixins.json
+++ b/src/main/resources/duradisplay.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.leclowndu93150.duradisplay.mixins",
+  "refmap": "mixins.duradisplay.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "GuiGraphicsMixin"
+  ]
+}


### PR DESCRIPTION
This introduces a mixin that prevents item bars(durability bars) from being drawn.